### PR TITLE
Cache grammar instance for repeated parsing

### DIFF
--- a/src/QueryParser.php
+++ b/src/QueryParser.php
@@ -4,6 +4,7 @@ namespace BrandEmbassy\QueryLanguageParser;
 
 use BrandEmbassy\QueryLanguageParser\Grammar\QueryLanguageGrammarConfiguration;
 use BrandEmbassy\QueryLanguageParser\Grammar\QueryLanguageGrammarFactory;
+use Ferno\Loco\Grammar;
 use Ferno\Loco\GrammarException;
 use Ferno\Loco\ParseFailureException;
 
@@ -19,6 +20,11 @@ final class QueryParser
      */
     private $grammarFactory;
 
+    /**
+     * @var Grammar|null
+     */
+    private $grammar;
+
 
     public function __construct(
         QueryLanguageGrammarConfiguration $grammarConfiguration,
@@ -26,6 +32,7 @@ final class QueryParser
     ) {
         $this->grammarConfiguration = $grammarConfiguration;
         $this->grammarFactory = $grammarFactory;
+        $this->grammar = null;
     }
 
 
@@ -36,15 +43,22 @@ final class QueryParser
      */
     public function parse(string $query)
     {
-        $fields = $this->grammarConfiguration->getFields();
-        $operators = $this->grammarConfiguration->getOperators();
-
         try {
-            $grammar = $this->grammarFactory->create($fields, $operators);
+            if ($this->grammar === null) {
+                $fields = $this->grammarConfiguration->getFields();
+                $operators = $this->grammarConfiguration->getOperators();
+                $this->grammar = $this->grammarFactory->create($fields, $operators);
+            }
 
-            return $grammar->parse($query);
+            return $this->grammar->parse($query);
         } catch (GrammarException | ParseFailureException $e) {
             throw UnableToParseQueryException::byOtherException($e);
         }
+    }
+
+
+    public function clearGrammarCache(): void
+    {
+        $this->grammar = null;
     }
 }

--- a/src/QueryParserGrammarCacheTest.php
+++ b/src/QueryParserGrammarCacheTest.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types = 1);
+
+namespace BrandEmbassy\QueryLanguageParser;
+
+use BrandEmbassy\QueryLanguageParser\Examples\Car\QueryLanguage\CarQueryParserFactory;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+final class QueryParserGrammarCacheTest extends TestCase
+{
+    public function testGrammarIsCachedBetweenParseCalls(): void
+    {
+        $parser = (new CarQueryParserFactory())->create();
+
+        $reflection = new ReflectionProperty(QueryParser::class, 'grammar');
+        $reflection->setAccessible(true);
+
+        $parser->parse('brand=bmw');
+        $firstGrammar = $reflection->getValue($parser);
+
+        $parser->parse('brand=audi');
+        $secondGrammar = $reflection->getValue($parser);
+
+        Assert::assertSame($firstGrammar, $secondGrammar);
+    }
+
+    public function testCacheCanBeCleared(): void
+    {
+        $parser = (new CarQueryParserFactory())->create();
+
+        $reflection = new ReflectionProperty(QueryParser::class, 'grammar');
+        $reflection->setAccessible(true);
+
+        $parser->parse('brand=bmw');
+        $firstGrammar = $reflection->getValue($parser);
+
+        $parser->clearGrammarCache();
+
+        $parser->parse('brand=audi');
+        $secondGrammar = $reflection->getValue($parser);
+
+        Assert::assertNotSame($firstGrammar, $secondGrammar);
+    }
+}


### PR DESCRIPTION
## Summary
- persist generated Grammar instance in `QueryParser`
- reuse Grammar across `parse()` calls and add a method to clear the cache
- test that grammar is cached and reused between parses

## Testing
- `phpunit` *(fails: `phpunit: No such file or directory`)*